### PR TITLE
Mirror local permissions with LocalArtifactInstallation

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+1.2.3 - 2017-06-20
+------------------
+* **Bug** - Fix bug where local permissions were not mirrored on the remote side when
+  using `LocalArtifactinstallation`.
+
 1.2.2 - 2016-05-06
 ------------------
 * **Bug** - Fix bug where newer version of ``cryptography`` module being pulled in than

--- a/test/unit/test_install.py
+++ b/test/unit/test_install.py
@@ -174,7 +174,10 @@ class TestLocalArtifactInstallation(object):
         self.runner.run.assert_called_once_with(
             "mkdir -p '/srv/www/myapp/releases/20141011145205'")
         self.runner.put.assert_called_once_with(
-            '/tmp/someapp-1.2.3.jar', '/srv/www/myapp/releases/20141011145205')
+            '/tmp/someapp-1.2.3.jar',
+            '/srv/www/myapp/releases/20141011145205',
+            mirror_local_mode=True
+        )
 
     def test_install_rename_artifact(self):
         self.runner.exists.return_value = True
@@ -186,7 +189,9 @@ class TestLocalArtifactInstallation(object):
 
         self.runner.put.assert_called_once_with(
             '/tmp/someapp-1.2.3.jar',
-            '/srv/www/myapp/releases/20141011145205/someapp.jar')
+            '/srv/www/myapp/releases/20141011145205/someapp.jar',
+            mirror_local_mode=True
+        )
 
     def test_install_do_not_rename(self):
         self.runner.exists.return_value = True
@@ -198,7 +203,9 @@ class TestLocalArtifactInstallation(object):
 
         self.runner.put.assert_called_once_with(
             '/tmp/someapp-1.2.3.jar',
-            '/srv/www/myapp/releases/20141011145205')
+            '/srv/www/myapp/releases/20141011145205',
+            mirror_local_mode=True
+        )
 
 
 class TestHttpArtifactInstallation(object):

--- a/tunic/__init__.py
+++ b/tunic/__init__.py
@@ -14,4 +14,4 @@ tunic
 Deployment related Fabric utilities.
 """
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/tunic/install.py
+++ b/tunic/install.py
@@ -279,7 +279,7 @@ class LocalArtifactInstallation(ProjectBaseMixin):
         else:
             destination = release_path
 
-        return self._runner.put(self._local_file, destination)
+        return self._runner.put(self._local_file, destination, mirror_local_mode=True)
 
 
 def download_url(url, destination, runner=None):


### PR DESCRIPTION
Allow support for installs using executables (C, Rust, Go)