### PR TITLE
Expose retry options in HttpArtifactInstallation

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+1.3.0 - 2017-08-31
+------------------
+* Add retry settings to :class:`tunic.install.HttpArtifactInstallation` to allow more
+  robust deploys over unreliable networks. Fixes `#8 <https://github.com/tshlabs/tunic/issues/8>`_.
+
 1.2.3 - 2017-06-20
 ------------------
 * **Bug** - Fix bug where local permissions were not mirrored on the remote side when

--- a/test/unit/test_install.py
+++ b/test/unit/test_install.py
@@ -243,27 +243,36 @@ class TestHttpArtifactInstallation(object):
         self.runner.exists.return_value = False
         installer = tunic.install.HttpArtifactInstallation(
             '/srv/www/myapp', 'http://localhost/app-1.2.3.jar',
-            downloader=self.downloader, runner=self.runner)
+            retries=2, retry_delay=1.0, downloader=self.downloader,
+            runner=self.runner)
 
         installer.install('20160206111401')
 
         self.runner.run.assert_called_once_with(
             "mkdir -p '/srv/www/myapp/releases/20160206111401'")
+
         self.downloader.assert_called_once_with(
             'http://localhost/app-1.2.3.jar',
-            '/srv/www/myapp/releases/20160206111401/app-1.2.3.jar')
+            '/srv/www/myapp/releases/20160206111401/app-1.2.3.jar',
+            retries=2,
+            retry_delay=1.0
+        )
 
     def test_install_rename_artifact(self):
         self.runner.exists.return_value = True
         installer = tunic.install.HttpArtifactInstallation(
             '/srv/www/myapp', 'http://localhost/app-1.2.3.jar',
-            remote_name='app.jar', downloader=self.downloader, runner=self.runner)
+            remote_name='app.jar', retries=2, retry_delay=1.0, downloader=self.downloader,
+            runner=self.runner)
 
         installer.install('20160206111401')
 
         self.downloader.assert_called_once_with(
             'http://localhost/app-1.2.3.jar',
-            '/srv/www/myapp/releases/20160206111401/app.jar')
+            '/srv/www/myapp/releases/20160206111401/app.jar',
+            retries=2,
+            retry_delay=1.0
+        )
 
 
 class TestLocalArtifactTransfer(object):

--- a/tunic/core.py
+++ b/tunic/core.py
@@ -59,6 +59,7 @@ PERMS_DIR_DEFAULT = 'u+rwx,g+rws,o+rx'
 RELEASE_DATE_FMT = '%Y%m%d%H%M%S'
 
 
+# pylint: disable=missing-docstring
 def _strip_all(parts):
     return [part.strip() for part in parts]
 
@@ -167,6 +168,7 @@ def get_release_id(version=None):
     :return: Unique name for this particular deployment
     :rtype: str
     """
+    # pylint: disable=invalid-name
     ts = datetime.utcnow().strftime(RELEASE_DATE_FMT)
 
     if version is None:
@@ -214,7 +216,7 @@ class FabRunner(object):
         return put(*args, **kwargs)
 
 
-def try_repeatedly(method, max_retries=1, delay=0):
+def try_repeatedly(method, max_retries=None, delay=None):
     """Execute the given Fabric call, retrying up to a certain number of times.
 
     The method is expected to be wrapper around a Fabric :func:`run` or :func:`sudo`
@@ -229,6 +231,8 @@ def try_repeatedly(method, max_retries=1, delay=0):
     :param float delay: Number of seconds between successive calls of :code:`method`
     :return: The results of running :code:`method`
     """
+    max_retries = max_retries if max_retries is not None else 1
+    delay = delay if delay is not None else 0
     tries = 0
 
     with warn_only():


### PR DESCRIPTION
Allow users of the HTTP installer class to easily specify retry logic
for more robust deploys over unreliable networks. Retry logic was
previously *possible* but hidden behind several layers of indirection.

Fixes #8